### PR TITLE
Ctrl-K to quick-select rooms (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
  "rumatui-tui 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
+ "sublime_fuzzy",
  "syntect",
  "termion",
  "tokio",
@@ -2289,6 +2290,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sublime_fuzzy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdac3d983d073c19487ba1f5e16eda43e9c6e50aa895d87110d0febe389b66b9"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-utilities"]
 edition = "2018"
 readme = "README.md"
 # at some point exclude this ??
-# exclude = ["resources"] 
+# exclude = ["resources"]
 
 [dependencies]
 async-trait = "0.1.30"
@@ -22,6 +22,7 @@ failure = "0.1.7"
 itertools = "0.9.0"
 js_int = "0.1.5"
 lazy_static = "1.4.0"
+sublime_fuzzy = "0.6.0"
 
 matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "037d62b" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,7 @@ fn main() -> Result<(), failure::Error> {
                             Key::Ctrl(c) if c == 'q' => app.should_quit = true,
                             Key::Ctrl(c) if c == 's' => app.on_send().await,
                             Key::Ctrl(c) if c == 'd' => app.on_ctrl_d().await,
+                            Key::Ctrl(c) if c == 'k' => app.on_ctrl_k().await,
                             Key::Up => app.on_up().await,
                             Key::Down => app.on_down().await,
                             Key::Left => app.on_left(),

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -844,6 +844,18 @@ impl AppWidget {
         }
     }
 
+    /// Filter current room list for quick-access
+    pub async fn on_ctrl_k(&mut self) {
+        let do_something = !self.chat.is_room_search();
+        if do_something {
+            if self.chat.is_quick_select() {
+                self.chat.quit_quick_select_room()
+            } else {
+                self.chat.start_quick_select_room()
+            }
+        }
+    }
+
     /// When a request is made to get previous room events (by scrolling up)
     /// the underlying client does not process them so we must deal with them.
     ///

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -361,15 +361,17 @@ impl AppWidget {
                     }
                     self.chat.push_search_text(c)
                 } else {
-                    // send typing notice to the server
-                    let room_id = self.chat.to_current_room_id();
-                    if !self.typing_notice {
-                        self.typing_notice = true;
-                        if let (Some(me), Some(room_id)) = (self.chat.to_current_user(), room_id) {
-                            if let Err(e) =
-                                self.send_jobs.send(UserRequest::Typing(room_id, me)).await
-                            {
-                                self.set_error(Error::from(e));
+                    if !self.chat.is_quick_select() {
+                        // send typing notice to the server
+                        let room_id = self.chat.to_current_room_id();
+                        if !self.typing_notice {
+                            self.typing_notice = true;
+                            if let (Some(me), Some(room_id)) = (self.chat.to_current_user(), room_id) {
+                                if let Err(e) =
+                                    self.send_jobs.send(UserRequest::Typing(room_id, me)).await
+                                {
+                                    self.set_error(Error::from(e));
+                                }
                             }
                         }
                     }

--- a/src/widgets/chat.rs
+++ b/src/widgets/chat.rs
@@ -178,10 +178,6 @@ impl ChatWidget {
         self.rooms_widget.start_quick_select_room();
     }
 
-    pub(crate) fn quick_select_room(&mut self, needle: &str) {
-        self.rooms_widget.quick_select_room(needle);
-    }
-
     pub(crate) fn is_quick_select(&self) -> bool {
         self.rooms_widget.is_quick_select()
     }
@@ -269,11 +265,19 @@ impl ChatWidget {
     }
 
     pub(crate) fn add_char(&mut self, ch: char) {
-        self.messages_widget.add_char(ch)
+        if self.is_quick_select() {
+            self.rooms_widget.quick_select_add_char(ch)
+        } else {
+            self.messages_widget.add_char(ch)
+        }
     }
 
     pub(crate) fn remove_char(&mut self) {
-        self.messages_widget.remove_char()
+        if self.is_quick_select() {
+            self.rooms_widget.quick_select_remove_char()
+        } else {
+            self.messages_widget.remove_char()
+        }
     }
 
     pub(crate) fn add_notify(&mut self, msg: &str) {

--- a/src/widgets/chat.rs
+++ b/src/widgets/chat.rs
@@ -169,6 +169,23 @@ impl ChatWidget {
         *self.current_room.borrow_mut() = Some(room.clone());
     }
 
+
+    pub(crate) fn quit_quick_select_room(&mut self) {
+        self.rooms_widget.quit_quick_select_room();
+    }
+
+    pub(crate) fn start_quick_select_room(&mut self) {
+        self.rooms_widget.start_quick_select_room();
+    }
+
+    pub(crate) fn quick_select_room(&mut self, needle: &str) {
+        self.rooms_widget.quick_select_room(needle);
+    }
+
+    pub(crate) fn is_quick_select(&self) -> bool {
+        self.rooms_widget.is_quick_select()
+    }
+
     pub(crate) fn as_current_user(&self) -> Option<&UserId> {
         self.me.as_ref()
     }


### PR DESCRIPTION
Functionality is basically done. 
One could use `format_simple` to highlight which letters have been matched. Didn't do this yet (not sure how yet), but left it imported for the moment. In case you are wondering about the compiler-warning because of unused.